### PR TITLE
Fix pg_restore error output

### DIFF
--- a/armada_sde/management/commands/pg_import_sde.py
+++ b/armada_sde/management/commands/pg_import_sde.py
@@ -64,9 +64,9 @@ class Command(BaseCommand):
         returncode = p.wait()
         if returncode != 0:
             sys.stdout.write('[FAILED]\n')
-            self.stdout.write(p.stdout.read())
+            self.stdout.write(str(p.stdout.read(), 'utf-8'))
             self.stdout.flush()
-            self.stderr.write(p.stderr.read())
+            self.stderr.write(str(p.stderr.read(), 'utf-8'))
             self.stderr.flush()
             sys.exit(returncode)
         sys.stdout.write('[DONE]\n')


### PR DESCRIPTION
Instead of printing the the `pg_restore` subprocesses output in case of failure, I just got following error traceback, so I threw some string conversion on that problem.
```
Dropping the evesde schema, if exists...
[DONE]
Starting import of database dump...[FAILED]
Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "virtualenv/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "virtualenv/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "virtualenv/lib/python3.6/site-packages/django/core/management/base.py", line 316, in run_from_argv
    self.execute(*args, **cmd_options)
  File "virtualenv/lib/python3.6/site-packages/django/core/management/base.py", line 353, in execute
    output = self.handle(*args, **options)
  File "virtualenv/lib/python3.6/site-packages/armada_sde/management/commands/pg_import_sde.py", line 98, in handle
    self.import_database(dump, dbalias)
  File "virtualenv/lib/python3.6/site-packages/armada_sde/management/commands/pg_import_sde.py", line 67, in import_database
    self.stdout.write(p.stdout.read())
  File "virtualenv/lib/python3.6/site-packages/django/core/management/base.py", line 142, in write
    if ending and not msg.endswith(ending):
TypeError: endswith first arg must be bytes or a tuple of bytes, not str
```